### PR TITLE
Luigi 1

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -3,6 +3,7 @@ List of TODOs that need implementing:
 	- list, arrays, and structs
 		- need to handle in scanner, parser, and semant
 		- need to implement functionality in c++
+		- literals to be implemented (if time allows?).
 	- implement ** (exponent) operator in parser (This seems to have been resolved)
 		- keeps reporting shift/reduce conflicts for some reason
 	- irgen stage

--- a/TODOs.txt
+++ b/TODOs.txt
@@ -3,7 +3,7 @@ List of TODOs that need implementing:
 	- list, arrays, and structs
 		- need to handle in scanner, parser, and semant
 		- need to implement functionality in c++
-	- implement ** (exponent) operator in parser
+	- implement ** (exponent) operator in parser (This seems to have been resolved)
 		- keeps reporting shift/reduce conflicts for some reason
 	- irgen stage
 		- fill in TODOs

--- a/parser.mly
+++ b/parser.mly
@@ -83,6 +83,7 @@ expr:
   | expr GT expr  { Binop($1, Gt, $3) }
   | expr LTE expr  { Binop($1, Lte, $3) }
   | expr GTE expr  { Binop($1, Gte, $3) }
+  | expr EXP expr  { Binop($1, Exp, $3) }
   | expr AND expr  { Binop($1, And, $3) }
   | expr OR expr  { Binop($1, Or, $3) }
   | NOT ID  { Unop($2, Not) }

--- a/scanner.mll
+++ b/scanner.mll
@@ -2,6 +2,9 @@
 
 let digit = ['0'-'9']
 let letter = ['a'-'z' 'A'-'Z']
+let str = '"'[^'"''\\']*('\\'_[^'"''\\']*)*'"'
+let flt = digit*'.'digit+ 
+let id = letter (digit | letter | '_')*
 
 rule token = parse 
     [' ' '\t' '\r' '\n']  { token lexbuf }
@@ -64,7 +67,8 @@ rule token = parse
   | digit+ as lem  { INTLIT(int_of_string lem) }
   | digit*'.'digit+ as lem  { FLOATLIT(float_of_string lem) }
   | '"'[^'"''\\']*('\\'_[^'"''\\']*)*'"' as lem  { STRLIT(lem) }
-  | "[.*]" as lem  { LSTLIT(lem) }   (* TODO: fix this regex *)
+  (* | "[.*]" as lem  { LSTLIT(lem) }   (* TODO: fix this regex *) *)
+  | "["((id (","" "*'\t'*'\n'*id)*)? | (digit+(','' '*'\t'*'\n'*digit+))? | (str(','' '*'\t'*'\n'*str)*)? | (flt(','' '*'\t'*'\n'*flt)*)?)"]" as lem { LSTLIT(lem) }
   | letter (digit | letter | '_')* as lem  { ID(lem) }
   | eof  { EOF }
   | _ as char  { raise (Failure("illegal character " ^ Char.escaped char)) }

--- a/scanner.mll
+++ b/scanner.mll
@@ -19,7 +19,7 @@ rule token = parse
   | "-"  { MINUS }
   | "/"  { DIVIDE }
   | "*"  { TIMES }
-  | "**"  { EXP }  
+  | "*""*"  { EXP }
   | "++"  { INC }  
   | "--"  { DEC }  
   | "%"  { MOD }

--- a/semant.ml
+++ b/semant.ml
@@ -47,6 +47,8 @@ let check stmts vars funcs =
 	  	    | Add when t1 = String -> String
 	  	    | Mult when t1 = Int -> Int
 	  	    | Mult when t1 = Float -> Float
+	  	    | Exp when t1 = Int -> Int
+	  	    | Exp when t1 = Float -> Float
 	  	    | Div -> Float
 	  	    | Mod -> Int
 	  	    | Eq | Neq -> Bool
@@ -58,7 +60,8 @@ let check stmts vars funcs =
 	  	  (var_map, func_map, (t, SBinop((t1, e1), op, (t2, e2))))
 	  	else 
 	  	  let t = match op with 
-	  	    | Add | Sub | Mult | Div when ((t1 = Int && t2 = Float) || (t1 = Float && t2 = Int)) -> Float
+(*	  	    | Add | Sub | Mult | Div when ((t1 = Int && t2 = Float) || (t1 = Float && t2 = Int)) -> Float*)
+            | Add | Sub | Mult | Div | Exp when ((t1 = Int && t2 = Float) || (t1 = Float && t2 = Int)) -> Float
 	  	    | _ -> raise (Failure err)
 	  	  in
 	  	  (var_map, func_map, (t, SBinop((t1, e1), op, (t2, e2))))


### PR DESCRIPTION
Small change to allow for ** exponent operator.

I am not sure why "**" caused a shift/reduce conflict while "*""*" does not. I thought that maybe, somehow, the lexer takes anything followed by a * as Kleene closure, even if it is inside of the double quotes, though that is just a wild guess. Nevertheless, everything compiles and there are no runtime errors for when something of the form number ** number; is entered. 